### PR TITLE
Dockerised app

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,5 +19,5 @@ UPLOADTHING_APP_ID=
 UPLOADTHING_SECRET=
 
 # Database Configuration (Prisma) 
-DATABASE_URL= 
+DATABASE_URL=mysql://user:password@localhost:3306/test
  

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "my-app",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@clerk/nextjs": "^4.23.3",
         "@hookform/resolvers": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prisma:generate": "prisma generate",
+    "prisma:push": "prisma db push",
+    "postinstall": "prisma generate",
+    "docker:build": "docker-compose -f src/docker/docker-compose.yml up --build",
+    "docker:database": "docker-compose -f src/docker/docker-compose.yml up db"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.23.3",

--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -1,0 +1,85 @@
+# **Dockerized Next.js and MySQL Full-Stack Application**
+
+This repository provides Docker configuration files for a Next.js full-stack application with a MySQL database backend. Using Docker, you can build and run the entire application stack in containers, ensuring a consistent development environment and easy deployment.
+
+# **Repository Structure**
+
+The Docker-related files are located within the `docker` directory at the root of the repository. The `docker` directory has the following structure:
+
+```
+docker/
+├── docker-compose.yml
+├── next/
+│   └── Dockerfile
+└── mysql/
+    └── Dockerfile
+
+```
+
+- `docker-compose.yml`: Docker Compose file used to orchestrate multi-container Docker applications.
+- `next/Dockerfile`: Dockerfile used to build the Next.js application.
+
+# **Docker Compose File (docker-compose.yml)**
+
+Docker Compose is a tool for defining and managing multi-container Docker applications. It uses YAML files to configure the application's services and handles the creation and startup of all the containers with a single command.
+
+The `docker-compose.yml` file for this project is configured to run both the Next.js application and a MySQL database.
+
+Here is a breakdown of what each section does:
+
+```yaml
+version: "3"
+
+services:
+  nextjs:
+    container_name: nextjs
+    build:
+      context: .. # root of the project
+      dockerfile: docker/next/Dockerfile
+    env_file:
+      - ../.env
+    ports:
+      - 3000:3000
+    depends_on:
+      - db
+
+  db:
+    container_name: database
+    build:
+      context: .. # root of the project
+      dockerfile: docker/mysql/Dockerfile # specify the path to your custom Dockerfile
+    image: custom-mysql:8.0 # optionally specify a custom image name
+    command: --default-authentication-plugin=mysql_native_password
+    env_file:
+      - ../.env
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - 3306:3306
+    volumes:
+      - mysqldata:/var/lib/mysql
+
+volumes:
+  mysqldata:
+```
+
+To run the MySQL database in a Docker container, use the following command:
+
+```bash
+docker-compose --env-file .env -f docker/docker-compose.yml up db
+```
+
+This command uses the `docker-compose.yml` file and the `.env` file to start the MySQL database container.
+
+# **Dockerfile for Next.js Application (next/Dockerfile)**
+
+The `next/Dockerfile` contains instructions that Docker uses to build the Next.js application's Docker image. It's a multi-stage build process, optimized for the Next.js app.
+
+The detailed explanation of this Dockerfile is provided in the `next` section.
+
+# **Development Database**
+
+The MySQL database is run using the `mysql` image and is configured with environment variables from the `.env` file. This allows you to easily spin up a development database with Docker. The `.env.example` file in the repository is already configured with the required variables to set up the database container. Simply copy this file to `.env` and adjust the values as needed.

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3"
+
+services:
+  nextjs:
+    container_name: nextjs
+    build:
+      context: .. # root of the project
+      dockerfile: docker/next/Dockerfile
+    ports:
+      - 3000:3000
+    depends_on:
+      - db
+
+  db:
+    container_name: database
+    build:
+      context: ..
+      dockerfile: docker/mysql/Dockerfile
+    image: custom-mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: test
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - 3306:3306
+    volumes:
+      - mysqldata:/var/lib/mysql
+
+volumes:
+  mysqldata:

--- a/src/docker/mysql/Dockerfile
+++ b/src/docker/mysql/Dockerfile
@@ -1,0 +1,5 @@
+FROM mysql:8.0
+
+# Ccustom scripts or extensions here if needed
+
+EXPOSE 3306

--- a/src/docker/next/Dockerfile
+++ b/src/docker/next/Dockerfile
@@ -1,0 +1,17 @@
+# ---- Build Stage ----
+FROM node:18.16.0-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN yarn install
+COPY . .
+RUN yarn build
+
+# ---- Release Stage ----
+FROM node:18.16.0-alpine AS release
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+RUN yarn install
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+CMD ["yarn", "start"]

--- a/src/docker/next/README.md
+++ b/src/docker/next/README.md
@@ -1,0 +1,94 @@
+This `Dockerfile` is located in the `docker/next/` directory and is used specifically for the Next.js application in the project. 
+
+# **Overview**
+
+This Dockerfile utilizes a multi-stage build process. In a multi-stage build, you use multiple `FROM` statements in your Dockerfile. Each `FROM` statement can use a different base, and each of them begins a new stage of the build. You can selectively copy artifacts from one stage to another, leaving behind everything you don’t want in the final image.
+
+Multi-stage builds are useful to anyone who has struggled to optimize Dockerfiles while keeping them easy to read and maintain.
+
+# **Breakdown of the Dockerfile**
+
+Below is a line-by-line explanation of each part of the `Dockerfile`.
+
+```Dockerfile
+# ---- Build Stage ----
+FROM node:18.16.0-alpine AS builder
+```
+
+This is the first stage of the multi-stage build. It uses the `node:18.16.0-alpine` Docker image as the base image. This image includes Node.js based on the 18.16.0 version and uses Alpine, a lightweight Docker image. The stage is named `builder`.
+
+```Dockerfile
+WORKDIR /app
+```
+
+Set the working directory to `/app`. All the instructions that follow in the `Dockerfile` will be run from this directory.
+
+```Dockerfile
+COPY package*.json ./
+```
+
+Copy the `package.json` and `package-lock.json` (if available) from your host to your image filesystem.
+
+```Dockerfile
+RUN npm install
+```
+
+Run the `npm install` command inside your image filesystem which installs the dependencies described in `package.json`.
+
+```Dockerfile
+COPY . .
+```
+
+Copy everything from the current directory in your host to the `WORKDIR` in your image filesystem.
+
+```Dockerfile
+RUN npm run build
+```
+
+This step will create an optimized production build of your Next.js application.
+
+```Dockerfile
+# ---- Release Stage ----
+FROM node:18.16.0-alpine AS release
+```
+
+This begins the second stage of the multi-stage build, also using `node:18.16.0-alpine` as the base image, named as `release`.
+
+```Dockerfile
+WORKDIR /app
+```
+
+Sets the working directory to `/app`.
+
+```Dockerfile
+COPY --from=builder /app/package*.json ./
+```
+
+This copies the `package.json` and `package-lock.json` (if available) from the `builder` stage to the current stage.
+
+```Dockerfile
+RUN npm install --only=production
+```
+
+This will install only the dependencies needed for running the application, and not the devDependencies, thus creating a leaner image.
+
+```Dockerfile
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+```
+
+These lines are copying the built Next.js app files and the public files from the `builder` stage into the `release` stage.
+
+```Dockerfile
+EXPOSE 3000
+```
+
+This informs Docker that the container listens on the specified network ports at runtime. In this case, it's port 3000.
+
+```Dockerfile
+CMD ["npm", "start"]
+```
+
+Provides defaults for executing a container, which includes the specifications of what executable to run when the container starts.
+
+In conclusion, this Dockerfile leverages the multi-stage build feature to create a lean, production-ready Docker image of your Next.js application. You start with a larger image containing everything needed to build your application, and then copy just the built application and its runtime dependencies into a smaller, final image.


### PR DESCRIPTION
- Build Next.JS app into image
- Added development MySQL database
- Added required scripts for Docker

---

The main part is the database. You can use Docker to start a MySQL database locally when developing to prevent any mistakes on the production PlanetScale database. I also added the default database URI on the `env.example` file so since the development credentials are the same. 

Bellow is a video demoing how the database works:

[Docker Demo.webm](https://github.com/hqasmei/site-muse/assets/58662575/dc9a7c5b-3f72-429c-8962-962130f081ee)
